### PR TITLE
Updated to Rust 2018 and Const Generics.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,4 @@ keywords = ["arm", "cortex-m", "atomic", "queue", "ringbuffer"]
 categories = ["embedded", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/thejpster/atomic-queue-rs"
-
-[dependencies]
-const-ft = { version =  "0.1" }
-
-[features]
-const = ["const-ft/const_fn"]
-
-[dev-dependencies]
-lazy_static = "1.1.0"
+edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,28 +1,20 @@
 # Atomic Queue
 
-This is a simple lock-free atomic queue for `#![no_std]` embedded systems written in Rust. The queue can be any length because the storage is supplied as a mutable slice at creation time.
+This is a simple lock-free atomic queue for `#![no_std]` embedded systems written in Rust.
+
+It will compile on any target with Atomic Compare-and-Swap (e.g. `thumbv7m-none-eabi` is OK, but 
+`thumbv6-none-eabi` is not).
 
 ```rust
-extern crate atomic_queue;
-#[macro_use]
-extern crate lazy_static;
-
 use atomic_queue::AtomicQueue;
 
 /// This is the static storage we use to back our queue
-static mut STORAGE: [u8; 16] = [0; 16];
-/// This is our queue. We need `lazy_static` because we can't refer to the storage above at compile time.
-lazy_static! {
-    static ref QUEUE: AtomicQueue<'static, u8> = {
-        let m = unsafe { AtomicQueue::new(&mut STORAGE) };
-        m
-    };
-}
+static QUEUE: AtomicQueue<u8, 16> = AtomicQueue::new([0u8; 16]);
 
 fn main() -> Result<(), ()> {
-    println!("Pushed 255");
-    QUEUE.push(255)?;
-    println!("Popped {:?}", QUEUE.pop());
-    Ok(())
+	println!("Pushed 255");
+	QUEUE.push(255)?;
+	println!("Popped {:?}", QUEUE.pop());
+	Ok(())
 }
 ```

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,21 +1,7 @@
-extern crate atomic_queue;
-#[macro_use]
-extern crate lazy_static;
-
 use atomic_queue::AtomicQueue;
 
 /// This is the static storage we use to back our queue
-static mut STORAGE: [u8; 16] = [0; 16];
-
-/// This is our queue, backed by `STORAGE`. We have to use `lazy_static!` to
-/// initialise this / because Rust won't let us have a `static` containing a
-/// mutable reference to another `static`.
-lazy_static! {
-	static ref QUEUE: AtomicQueue<'static, u8> = {
-		let m = unsafe { AtomicQueue::new(&mut STORAGE) };
-		m
-	};
-}
+static QUEUE: AtomicQueue<u8, 16> = AtomicQueue::new([0u8; 16]);
 
 fn main() -> Result<(), ()> {
 	println!("Pushed 255");


### PR DESCRIPTION
The data is now stored inside the struct instead of as a reference.